### PR TITLE
BLDK-734:RDK License header changes-for Notice header update

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -8,8 +8,14 @@ See: com.comcast.hydra.astyanax.util.PropertiesConfiguration
 Apache Shindig OpenSocial API:
 See: com.comcast.hesperius.dataaccess.support.BufferedServletRequestWrapper
 
-Copyright 2018 RDK Management
-Licensed under the Apache License, Version 2.0
+This component contains software that is Copyright (c) 2018 RDK Management.
+The component is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use the component except in compliance with the License.
+
+The component may include material which is licensed under other licenses / copyrights as
+listed below. Your use of this material within the component is also subject to the terms and
+conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
+within this component.
 
 Copyright 2013 Netflix, Inc.
 Licensed under the Apache License, Version 2.0


### PR DESCRIPTION
Reason for change: RDK License header changes-for Notice header update