### PR TITLE
BLDK-724:NOTICE File change for License update

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,3 +1,12 @@
+This component contains software that is Copyright (c) 2018 RDK Management.
+The component is licensed to you under the Apache License, Version 2.0 (the "License").
+You may not use the component except in compliance with the License.
+
+The component may include material which is licensed under other licenses / copyrights as
+listed below. Your use of this material within the component is also subject to the terms and
+conditions of these licenses. The LICENSE file contains the text of all the licenses which apply
+within this component.
+
 Apache Commons Configuration and Apache Shindig OpenSocial:
 Copyright 2001-2013 The Apache Software Foundation
 This product includes software developed at
@@ -7,9 +16,6 @@ Apache Common Configuration:
 See: com.comcast.hydra.astyanax.util.PropertiesConfiguration
 Apache Shindig OpenSocial API:
 See: com.comcast.hesperius.dataaccess.support.BufferedServletRequestWrapper
-
-Copyright 2018 RDK Management
-Licensed under the Apache License, Version 2.0
 
 Copyright 2013 Netflix, Inc.
 Licensed under the Apache License, Version 2.0


### PR DESCRIPTION
Reason for change: NOTICE File change for License update
Test Procedure: Jenkin build should pass after License header changes for RDK for listed repos
BLDK-724:NOTICE File change for License update
Risks: None